### PR TITLE
Adding anonymous option to posting a topic

### DIFF
--- a/public/openapi/read/topic/topic_id.yaml
+++ b/public/openapi/read/topic/topic_id.yaml
@@ -42,6 +42,8 @@ get:
                     nullable: true
                   titleRaw:
                     type: string
+                  isAnonymous:
+                    type: boolean
                   tags:
                     type: array
                     items:

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -82,6 +82,7 @@ module.exports = function (Topics) {
 
         data.title = String(data.title).trim();
         data.tags = data.tags || [];
+        data.isAnonymous = data.tags.includes("anonymous")
         if (data.content) {
             data.content = utils.rtrim(data.content);
         }

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -33,9 +33,11 @@ module.exports = function (Topics) {
             lastposttime: 0,
             postcount: 0,
             viewcount: 0,
+            isAnonymous: false
         };
 
         if (Array.isArray(data.tags) && data.tags.length) {
+            topicData.isAnonymous = data.tags.includes("anonymous") || data.tags.includes("Anonymous")
             topicData.tags = data.tags.join(',');
         }
 
@@ -82,7 +84,6 @@ module.exports = function (Topics) {
 
         data.title = String(data.title).trim();
         data.tags = data.tags || [];
-        data.isAnonymous = data.tags.includes("anonymous")
         if (data.content) {
             data.content = utils.rtrim(data.content);
         }

--- a/src/topics/create.js
+++ b/src/topics/create.js
@@ -37,7 +37,6 @@ module.exports = function (Topics) {
         };
 
         if (Array.isArray(data.tags) && data.tags.length) {
-            topicData.isAnonymous = data.tags.includes("anonymous") || data.tags.includes("Anonymous")
             topicData.tags = data.tags.join(',');
         }
 

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -139,4 +139,9 @@ function modifyTopic(topic, fields) {
             };
         });
     }
+    
+    if (topic.tags){
+        if (topic.tags.includes("anonymous") || topic.tags.includes("Anonymous"))
+        topic.isAnonymous = true;
+    }
 }

--- a/src/topics/data.js
+++ b/src/topics/data.js
@@ -141,7 +141,6 @@ function modifyTopic(topic, fields) {
     }
     
     if (topic.tags){
-        if (topic.tags.includes("anonymous") || topic.tags.includes("Anonymous"))
-        topic.isAnonymous = true;
+        topic.isAnonymous = topic.tags.reduce((a, b) => a || b.value == "anonymous" || b.value == "Anonymous", false);
     }
 }

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -8,12 +8,11 @@
 
     <small class="pull-left">
         <strong>
-            {{{if tags}}}
-            HIII
+            {{{if isAnonymous}}}
+            Anonymous
             {{{else}}}
-            BAD
-            {{{END}}}
             <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
+            {{{end}}}
         </strong>
 
         <!-- IMPORT partials/topic/badge.tpl -->

--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -8,6 +8,11 @@
 
     <small class="pull-left">
         <strong>
+            {{{if tags}}}
+            HIII
+            {{{else}}}
+            BAD
+            {{{END}}}
             <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
         </strong>
 


### PR DESCRIPTION
Added anonymous posting on top of the existing NodeBB tag system. Resolves #9 #10. 

**TODO**
Add this filter to other fields in the template files. Right now we can still see profile pictures and "edited by <user>". These fields should also be filtered out.