### PR TITLE
Hide profile pictures for anonymous posts

### DIFF
--- a/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
+++ b/themes/nodebb-theme-persona/templates/partials/topic/post.tpl
@@ -1,21 +1,34 @@
 <div class="clearfix post-header">
     <div class="icon pull-left">
+        {{{if isAnonymous}}}
+        
+        <a href="#">
+            <div style = "width:48px;height:48px;background-color: #aaa;border-radius: 50%"></div>
+        </a>
+        {{{else}}}
         <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->">
             {buildAvatar(posts.user, "sm2x", true, "", "user/picture")}
             <i component="user/status" class="fa fa-circle status {posts.user.status}" title="[[global:{posts.user.status}]]"></i>
         </a>
+        {{{end}}}
     </div>
 
     <small class="pull-left">
         <strong>
+            {{isAdminOrMod}} 
             {{{if isAnonymous}}}
             Anonymous
             {{{else}}}
             <a href="<!-- IF posts.user.userslug -->{config.relative_path}/user/{posts.user.userslug}<!-- ELSE -->#<!-- ENDIF posts.user.userslug -->" itemprop="author" data-username="{posts.user.username}" data-uid="{posts.user.uid}">{posts.user.displayname}</a>
             {{{end}}}
+
+            
+
         </strong>
 
         <!-- IMPORT partials/topic/badge.tpl -->
+
+        
 
         <!-- IF posts.user.banned -->
         <span class="label label-danger">[[user:banned]]</span>


### PR DESCRIPTION
Built on top of the existing anonymous structure to hide profile picture as well. Now an anonymous post view completely hides the author.

Next steps:
- make the anonymized profile picture look prettier
- Make anonymous in view of all topics as well.

closes #12 since there is no "edited by" field in production.